### PR TITLE
[mod/#11] 포인트 상세화면 GUI 적용

### DIFF
--- a/app/src/main/java/org/sopt/sopt_collaboration_panelnow/core/designsystem/theme/Theme.kt
+++ b/app/src/main/java/org/sopt/sopt_collaboration_panelnow/core/designsystem/theme/Theme.kt
@@ -4,15 +4,28 @@ import android.app.Activity
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
+
+
+object PanelNowTheme {
+    val colors: PanelNowColors
+        @Composable
+        @ReadOnlyComposable
+        get() = LocalPanelNowColorsProvider.current
+    val typography: PanelNowTypography
+        @Composable
+        @ReadOnlyComposable
+        get() = LocalPanelNowTypographyProvider.current
+}
 
 @Composable
 fun ProvidePanelNowColorsAndTypography(
     colors: PanelNowColors,
     typography: PanelNowTypography,
-    content: @Composable () -> Unit
+    content: @Composable () -> Unit,
 ) {
     CompositionLocalProvider(
         LocalPanelNowColorsProvider provides colors,
@@ -23,7 +36,7 @@ fun ProvidePanelNowColorsAndTypography(
 
 @Composable
 fun PanelNowTheme(
-    content: @Composable () -> Unit
+    content: @Composable () -> Unit,
 ) {
     ProvidePanelNowColorsAndTypography(
         colors = defaultPanelNowColors,

--- a/app/src/main/java/org/sopt/sopt_collaboration_panelnow/presentation/pointdetail/PointDetailScreen.kt
+++ b/app/src/main/java/org/sopt/sopt_collaboration_panelnow/presentation/pointdetail/PointDetailScreen.kt
@@ -1,6 +1,7 @@
 package org.sopt.sopt_collaboration_panelnow.presentation.pointdetail
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.LazyColumn
@@ -9,6 +10,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import org.sopt.sopt_collaboration_panelnow.core.designsystem.theme.PanelNowTheme
 import org.sopt.sopt_collaboration_panelnow.presentation.pointdetail.component.PointCouponSection
 import org.sopt.sopt_collaboration_panelnow.presentation.pointdetail.component.PointGoodsSection
 import org.sopt.sopt_collaboration_panelnow.presentation.pointdetail.component.PointGuideSection
@@ -34,8 +37,9 @@ fun PointDetailScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .background(
-                    color = Color.White
-                )
+                    color = PanelNowTheme.colors.gray4
+                ),
+            verticalArrangement = Arrangement.spacedBy(6.dp)
         ) {
             item {
                 PointImageSection(

--- a/app/src/main/java/org/sopt/sopt_collaboration_panelnow/presentation/pointdetail/component/PointCouponSection.kt
+++ b/app/src/main/java/org/sopt/sopt_collaboration_panelnow/presentation/pointdetail/component/PointCouponSection.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import org.sopt.sopt_collaboration_panelnow.R
+import org.sopt.sopt_collaboration_panelnow.core.designsystem.theme.PanelNowTheme
 
 @Composable
 fun PointCouponSection(
@@ -32,19 +33,28 @@ fun PointCouponSection(
     Column(
         modifier = modifier
             .fillMaxWidth()
+            .background(
+                color = PanelNowTheme.colors.white
+            )
             .padding(horizontal = 16.dp, vertical = 16.dp),
         verticalArrangement = Arrangement.spacedBy(17.dp),
     ) {
         Text(
             text = couponName,
+            style = PanelNowTheme.typography.titleSb20,
+            color = PanelNowTheme.colors.gray6,
         )
 
         Text(
-            text = stringResource(id = R.string.point_detail_description)
+            text = stringResource(id = R.string.point_detail_description),
+            style = PanelNowTheme.typography.titleM12,
+            color = PanelNowTheme.colors.gray1,
         )
 
         Text(
             text = couponPoint,
+            style = PanelNowTheme.typography.titleBd24,
+            color = PanelNowTheme.colors.mainBlue,
         )
 
         CouponInfo(
@@ -64,7 +74,7 @@ private fun CouponInfo(
         modifier = modifier
             .fillMaxWidth()
             .background(
-                color = Color.Gray,
+                color = PanelNowTheme.colors.gray4,
                 shape = RoundedCornerShape(10.dp)
             )
             .padding(vertical = 16.dp),
@@ -76,19 +86,23 @@ private fun CouponInfo(
                 .fillMaxWidth()
                 .padding(
                     horizontal = 16.dp,
-                    vertical = 7.dp
+                    vertical = 10.dp
                 ),
             horizontalArrangement = Arrangement.spacedBy(9.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
             Text(
-                text = stringResource(id = R.string.point_detail_coupon_locate)
+                text = stringResource(id = R.string.point_detail_coupon_locate),
+                style = PanelNowTheme.typography.titleM14,
+                color = PanelNowTheme.colors.gray1,
             )
 
             Spacer(modifier = Modifier.weight(1f))
 
             Text(
-                text = phoneNumber
+                text = phoneNumber,
+                style = PanelNowTheme.typography.bodyR16,
+                color = PanelNowTheme.colors.gray6,
             )
 
             Icon(
@@ -97,36 +111,43 @@ private fun CouponInfo(
                 tint = Color.Unspecified
             )
         }
-
         Row(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(
                     horizontal = 16.dp,
-                    vertical = 7.dp
+                    vertical = 6.dp
                 ),
             horizontalArrangement = Arrangement.Center,
         ) {
             Text(
-                text = stringResource(id = R.string.point_detail_coupon_date)
+                text = stringResource(id = R.string.point_detail_coupon_date),
+                style = PanelNowTheme.typography.titleM14,
+                color = PanelNowTheme.colors.gray1,
             )
 
             Spacer(modifier = Modifier.weight(1f))
 
             Text(
-                text = exchangeDate
+                text = exchangeDate,
+                style = PanelNowTheme.typography.bodyR16,
+                color = PanelNowTheme.colors.mainBlue,
             )
         }
     }
+
 }
+
 
 @Preview(showBackground = true)
 @Composable
 private fun PreviewPointCouponSection() {
-    PointCouponSection(
-        couponName = "Sample Coupon",
-        couponPoint = "1000 points",
-        phoneNumber = "123-456-7890",
-        exchangeDate = "2023-12-31",
-    )
+    PanelNowTheme {
+        PointCouponSection(
+            couponName = "Sample Coupon",
+            couponPoint = "5,000P",
+            phoneNumber = "01040000000",
+            exchangeDate = "2023-12-31",
+        )
+    }
 }

--- a/app/src/main/java/org/sopt/sopt_collaboration_panelnow/presentation/pointdetail/component/PointGoodsSection.kt
+++ b/app/src/main/java/org/sopt/sopt_collaboration_panelnow/presentation/pointdetail/component/PointGoodsSection.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import org.sopt.sopt_collaboration_panelnow.R
+import org.sopt.sopt_collaboration_panelnow.core.designsystem.theme.PanelNowTheme
 
 @Composable
 fun PointGoodsSection(
@@ -31,12 +32,16 @@ fun PointGoodsSection(
     ) {
         Text(
             text = stringResource(id = R.string.point_detail_goods_detail),
+            style = PanelNowTheme.typography.titleSb16,
+            color = PanelNowTheme.colors.gray6,
             modifier = Modifier
                 .align(Alignment.Start),
         )
 
         Text(
-            text = detailText
+            text = detailText,
+            style = PanelNowTheme.typography.bodyR14,
+            color = PanelNowTheme.colors.gray6,
         )
     }
 }
@@ -44,7 +49,9 @@ fun PointGoodsSection(
 @Preview(showBackground = true)
 @Composable
 private fun ReviewPointGoodsSection() {
-    PointGoodsSection(
-        detailText = "상품 상세 정보",
-    )
+    PanelNowTheme {
+        PointGoodsSection(
+            detailText = "상품 상세 정보",
+        )
+    }
 }

--- a/app/src/main/java/org/sopt/sopt_collaboration_panelnow/presentation/pointdetail/component/PointGuideSection.kt
+++ b/app/src/main/java/org/sopt/sopt_collaboration_panelnow/presentation/pointdetail/component/PointGuideSection.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import org.sopt.sopt_collaboration_panelnow.R
+import org.sopt.sopt_collaboration_panelnow.core.designsystem.theme.PanelNowTheme
 
 @Composable
 fun PointGuideSection(
@@ -30,13 +31,17 @@ fun PointGuideSection(
         verticalArrangement = Arrangement.spacedBy(10.dp)
     ) {
         Text(
-            text = stringResource(id= R.string.point_detail_guide),
+            text = stringResource(id = R.string.point_detail_guide),
+            style = PanelNowTheme.typography.titleSb16,
+            color = PanelNowTheme.colors.gray6,
             modifier = Modifier
                 .align(Alignment.Start),
         )
 
         Text(
-            text = guideText
+            text = guideText,
+            style = PanelNowTheme.typography.bodyR14,
+            color = PanelNowTheme.colors.gray6,
         )
     }
 }
@@ -44,7 +49,9 @@ fun PointGuideSection(
 @Preview(showBackground = true)
 @Composable
 private fun PreviewPointGuideSection() {
-    PointGuideSection(
-        guideText = "포인트 상세 설명 예시 텍스트"
-    )
+    PanelNowTheme {
+        PointGuideSection(
+            guideText = "포인트 상세 설명 예시 텍스트"
+        )
+    }
 }

--- a/app/src/main/java/org/sopt/sopt_collaboration_panelnow/presentation/pointdetail/component/PointPaySection.kt
+++ b/app/src/main/java/org/sopt/sopt_collaboration_panelnow/presentation/pointdetail/component/PointPaySection.kt
@@ -4,26 +4,25 @@ import androidx.annotation.DrawableRes
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.dropShadow
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.Shadow
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
+import org.sopt.sopt_collaboration_panelnow.R
 import org.sopt.sopt_collaboration_panelnow.core.common.extension.noRippleClickable
+import org.sopt.sopt_collaboration_panelnow.core.designsystem.theme.PanelNowTheme
 
 @Composable
 fun PointPaySection(
@@ -31,26 +30,34 @@ fun PointPaySection(
     myPoint: String,
     modifier: Modifier = Modifier,
     canPayed: Boolean = false,
-    @DrawableRes IconRes: Int? = null,
+    @DrawableRes iconRes: Int? = null,
 ) {
-    val ButtonWidth = when (canPayed) {
+    val buttonWidth = when (canPayed) {
         true -> 1F
-        false -> 0F
+        false -> 0.1F
     }
 
     Row(
         modifier = modifier
             .fillMaxWidth()
+            .background(
+                color = PanelNowTheme.colors.white
+            )
             .padding(horizontal = 16.dp, vertical = 16.dp),
-        horizontalArrangement = Arrangement.Center,
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        IconRes?.let {
+        iconRes?.let {
             Icon(
                 imageVector = ImageVector.vectorResource(id = it),
                 contentDescription = null,
+                tint = Color.Unspecified
             )
         }
+
+        Text(
+            text = "나의 포인트"
+        )
 
         Text(
             text = myPoint
@@ -59,7 +66,7 @@ fun PointPaySection(
         PayButton(
             label = label,
             onPayClick = { /*TODO*/ },
-            modifier = Modifier.weight(ButtonWidth),
+            modifier = Modifier.weight(buttonWidth),
             isEnabled = canPayed
         )
 
@@ -73,11 +80,9 @@ private fun PayButton(
     modifier: Modifier = Modifier,
     isEnabled: Boolean = false,
 ) {
-    val (backgroundColor, textColor) = remember(isEnabled) {
-        when (isEnabled) {
-            true -> Color.Blue to Color.White
-            false -> Color.Gray to Color.White
-        }
+    val backgroundColor = when (isEnabled) {
+        true -> PanelNowTheme.colors.mainBlue
+        false -> PanelNowTheme.colors.gray2
     }
 
     Box(
@@ -97,7 +102,8 @@ private fun PayButton(
     ) {
         Text(
             text = label,
-            color = textColor,
+            style = PanelNowTheme.typography.titleSb16,
+            color = PanelNowTheme.colors.white
         )
     }
 }
@@ -105,8 +111,24 @@ private fun PayButton(
 @Preview(showBackground = true)
 @Composable
 private fun ReviewPointPaySection() {
-    PointPaySection(
-        label = "1000원 결제하기",
-        myPoint = "1000",
-    )
+    PanelNowTheme {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .size(240.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            PointPaySection(
+                label = "1000원 결제하기",
+                myPoint = "1000",
+            )
+
+            PointPaySection(
+                label = "1000원 결제하기",
+                myPoint = "1000",
+                canPayed = true,
+                iconRes = R.drawable.ic_point
+            )
+        }
+    }
 }

--- a/app/src/main/res/drawable/ic_point_detail_visible_point.xml
+++ b/app/src/main/res/drawable/ic_point_detail_visible_point.xml
@@ -1,0 +1,14 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="20dp"
+    android:height="20dp"
+    android:viewportWidth="20"
+    android:viewportHeight="20">
+  <path
+      android:pathData="M10,10m-9,0a9,9 0,1 1,18 0a9,9 0,1 1,-18 0"
+      android:strokeWidth="2"
+      android:fillColor="#00A8FF"
+      android:strokeColor="#00A8FF"/>
+  <path
+      android:pathData="M7.5,5H10.827C11.566,5 12.186,5.138 12.686,5.414C13.186,5.691 13.558,6.068 13.802,6.547C14.045,7.021 14.167,7.564 14.167,8.177C14.167,8.785 14.045,9.328 13.802,9.807C13.558,10.285 13.186,10.665 12.686,10.946C12.19,11.227 11.575,11.367 10.84,11.367H8.46V10.262H10.786C11.291,10.262 11.705,10.173 12.03,9.993C12.355,9.814 12.589,9.57 12.733,9.261C12.882,8.953 12.959,8.591 12.963,8.177C12.959,7.762 12.882,7.401 12.733,7.093C12.589,6.784 12.352,6.542 12.023,6.367C11.699,6.192 11.282,6.105 10.773,6.105H8.717V15H7.5V5Z"
+      android:fillColor="#ffffff"/>
+</vector>

--- a/app/src/main/res/drawable/img_point_character.xml
+++ b/app/src/main/res/drawable/img_point_character.xml
@@ -1,9 +1,0 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="138dp"
-    android:height="64dp"
-    android:viewportWidth="138"
-    android:viewportHeight="64">
-  <path
-      android:pathData="M0,0h138v64h-138z"
-      android:fillColor="url(#pattern0_2306_915)"/>
-</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,7 +5,7 @@
     <string name="point_detail_image">point_detail_image</string>
     <string name="point_detail_description">포인트를 모바일 쿠폰으로 교환해보세요!\n더 편리하게 패널나우 포인트를 사용할 수 있어요.</string>
     <string name="point_detail_coupon_date">교환 예정일</string>
-    <string name="point_detail_coupon_locate">받으실 곧</string>
+    <string name="point_detail_coupon_locate">받으실 곳</string>
     <string name="point_detail_goods_detail">상품 상세</string>
     <string name="point_detail_guide">이용 안내</string>
 </resources>


### PR DESCRIPTION
## 📌 PR 요약

작업한 내용
-  포인트 교환 (상세화면) GUI 적용
- Icon 추가 및 string 추출
- DS theme fix 

PR 포인트 (to.reviewer)
- theme 쪽 수정했으니까 GUI 적용할 때 사용해주세용
- 솝커톤 전에 빠르게 작업하느라, 아직 button 쪽 section은 완성못했어요, 서버 연동할 때 같이 손볼게유
- 아 pr template 적용 드디어 되네

## 📸 스크린샷
|                스크린샷                |
|:----------------------------------:|
| <img width="360" src="https://github.com/user-attachments/assets/69402295-cf31-4d7f-b044-b21339008082" /> |


## 📮 관련 이슈
- closed #11 
