### PR TITLE
[feat/#26] 포인트 교환 API 연동 및 디자인 수정

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools">
-    <uses-permission android:name="android.permission.INTERNET"/>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-permission android:name="android.permission.INTERNET" />
     <application
         android:name=".PanelNowApplication"
         android:allowBackup="true"
@@ -11,13 +11,13 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/Theme.SOPT_COLLABORATION_PANELNOW"
+        android:theme="@style/Theme.PanelNow"
         android:usesCleartextTraffic="true">
         <activity
             android:name=".presentation.main.MainActivity"
             android:exported="true"
             android:label="@string/app_name"
-            android:theme="@style/Theme.SOPT_COLLABORATION_PANELNOW">
+            android:theme="@style/Theme.PanelNow">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/org/sopt/sopt_collaboration_panelnow/core/common/extension/Modifier.kt
+++ b/app/src/main/java/org/sopt/sopt_collaboration_panelnow/core/common/extension/Modifier.kt
@@ -1,10 +1,23 @@
 package org.sopt.sopt_collaboration_panelnow.core.common.extension
 
+import android.graphics.BlurMaskFilter
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Paint
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.drawOutline
+import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import org.sopt.sopt_collaboration_panelnow.core.designsystem.theme.PanelNowTheme
 
 fun Modifier.noRippleClickable(onClick: () -> Unit): Modifier = composed {
     this.clickable(
@@ -12,5 +25,49 @@ fun Modifier.noRippleClickable(onClick: () -> Unit): Modifier = composed {
         interactionSource = remember { MutableInteractionSource() }
     ) {
         onClick()
+    }
+}
+
+@Composable
+fun Modifier.dropShadow(
+    shape: Shape,
+    color: Color = PanelNowTheme.colors.black.copy(alpha = 0.1f),
+    blur: Dp = 1.dp,
+    offsetY: Dp = 1.dp,
+    offsetX: Dp = 1.dp,
+    spread: Dp = 1.dp
+) = composed {
+    val density = LocalDensity.current
+
+    val paint = remember(color, blur) {
+        Paint().apply {
+            this.color = color
+            val blurPx = with(density) { blur.toPx() }
+            if (blurPx > 0f) {
+                this.asFrameworkPaint().maskFilter =
+                    BlurMaskFilter(blurPx, BlurMaskFilter.Blur.NORMAL)
+            }
+        }
+    }
+
+    drawBehind {
+        val spreadPx = spread.toPx()
+        val offsetXPx = offsetX.toPx()
+        val offsetYPx = offsetY.toPx()
+
+        val shadowWidth = size.width + spreadPx
+        val shadowHeight = size.height + spreadPx
+
+        if (shadowWidth <= 0f || shadowHeight <= 0f) return@drawBehind
+
+        val shadowSize = Size(shadowWidth, shadowHeight)
+        val shadowOutline = shape.createOutline(shadowSize, layoutDirection, this)
+
+        drawIntoCanvas { canvas ->
+            canvas.save()
+            canvas.translate(offsetXPx, offsetYPx)
+            canvas.drawOutline(shadowOutline, paint)
+            canvas.restore()
+        }
     }
 }

--- a/app/src/main/java/org/sopt/sopt_collaboration_panelnow/core/common/util/Formating.kt
+++ b/app/src/main/java/org/sopt/sopt_collaboration_panelnow/core/common/util/Formating.kt
@@ -1,0 +1,33 @@
+
+package org.sopt.sopt_collaboration_panelnow.core.common.util
+
+import java.text.NumberFormat
+import java.util.Locale
+
+fun Long.toPointFormat(): String {
+    val formatter = NumberFormat.getNumberInstance(Locale.KOREA)
+    return "${formatter.format(this)}P"
+}
+
+fun String.toPointFormat(): String {
+    return try {
+        val number = this.toLongOrNull() ?: return "${this}P"
+        number.toPointFormat()
+    } catch (e: Exception) {
+        "${this}P"
+    }
+}
+
+fun String.maskPhoneNumber(): String {
+    val digitsOnly = this.filter { it.isDigit() }
+
+    return when (digitsOnly.length) {
+        11 -> {
+            "${digitsOnly.substring(0, 5)}******"
+        }
+        10 -> {
+            "${digitsOnly.substring(0, 5)}*****"
+        }
+        else -> this
+    }
+}

--- a/app/src/main/java/org/sopt/sopt_collaboration_panelnow/core/designsystem/theme/Color.kt
+++ b/app/src/main/java/org/sopt/sopt_collaboration_panelnow/core/designsystem/theme/Color.kt
@@ -18,6 +18,8 @@ val Gray6 = Color(0xFF00152C)
 
 val White = Color(0xFFFFFFFF)
 
+val Black = Color(0xFF000000)
+
 @Immutable
 data class PanelNowColors(
     val mainBlue: Color,
@@ -32,7 +34,8 @@ data class PanelNowColors(
     val gray5: Color,
     val gray6: Color,
 
-    val white: Color
+    val white: Color,
+    val black: Color
 )
 
 val defaultPanelNowColors = PanelNowColors(
@@ -48,7 +51,8 @@ val defaultPanelNowColors = PanelNowColors(
     gray5 = Gray5,
     gray6 = Gray6,
 
-    white = White
+    white = White,
+    black = Black
 )
 
 val LocalPanelNowColorsProvider = staticCompositionLocalOf { defaultPanelNowColors }

--- a/app/src/main/java/org/sopt/sopt_collaboration_panelnow/core/designsystem/theme/Type.kt
+++ b/app/src/main/java/org/sopt/sopt_collaboration_panelnow/core/designsystem/theme/Type.kt
@@ -61,7 +61,7 @@ val defaultPanelNowTypography = PanelNowTypography(
         fontFamily = PanelNowFontMedium,
         fontWeight = FontWeight.W500,
         fontSize = 12.sp,
-        lineHeight = 12.sp,
+        lineHeight = (12 * 1.4).sp,
         letterSpacing = 0.sp
     ),
 
@@ -76,7 +76,7 @@ val defaultPanelNowTypography = PanelNowTypography(
         fontFamily = PanelNowFontRegular,
         fontWeight = FontWeight.W400,
         fontSize = 14.sp,
-        lineHeight = 14.sp,
+        lineHeight = (14 * 1.35).sp,
         letterSpacing = 0.sp
     ),
     bodyM12 = TextStyle(

--- a/app/src/main/java/org/sopt/sopt_collaboration_panelnow/data/mapper/GoodsCheckMapper.kt
+++ b/app/src/main/java/org/sopt/sopt_collaboration_panelnow/data/mapper/GoodsCheckMapper.kt
@@ -1,22 +1,25 @@
 package org.sopt.sopt_collaboration_panelnow.data.mapper
 
 import org.sopt.sopt_collaboration_panelnow.data.remote.dto.response.GoodsCheckResponse
+import org.sopt.sopt_collaboration_panelnow.data.remote.dto.response.InfoSectionResponse
 import org.sopt.sopt_collaboration_panelnow.domain.entity.GoodsCheck
+import org.sopt.sopt_collaboration_panelnow.domain.entity.InfoSection
 
 fun GoodsCheckResponse.toGoodsCheck(): GoodsCheck {
-    val infoContent = infoSections.find { it.label == "충전권 이용안내" }?.content ?: ""
-    val usageManualContent = infoSections.find { it.label == "사용방법" }?.content ?: ""
-    val guideContent = infoSections.find { it.label == "이용가이드" }?.content ?: ""
-
     return GoodsCheck(
         id = id,
         imageUrl = imageUrl,
         name = name,
-        price = price,
+        price = price.toInt(),
         phoneNumber = phoneNumber,
         exchangeDay = exchangeDay,
-        info = infoContent,
-        usageManual = usageManualContent,
-        guide = guideContent,
+        infoSections = infoSections.map { it.toInfoSection() }
+    )
+}
+
+fun InfoSectionResponse.toInfoSection(): InfoSection {
+    return InfoSection(
+        label = label,
+        content = content
     )
 }

--- a/app/src/main/java/org/sopt/sopt_collaboration_panelnow/data/remote/datasource/GoodsCheckDataSource.kt
+++ b/app/src/main/java/org/sopt/sopt_collaboration_panelnow/data/remote/datasource/GoodsCheckDataSource.kt
@@ -8,5 +8,5 @@ import org.sopt.sopt_collaboration_panelnow.data.remote.dto.response.PurchaseRes
 interface GoodsCheckDataSource {
     suspend fun getProducts(sort: String): BaseResponse<List<ProductResponse>>
     suspend fun getGoodsCheck(productId: Int): BaseResponse<GoodsCheckResponse>
-    suspend fun postPurchase(userId: Long, productId: Int): BaseResponse<PurchaseResponse>
+    suspend fun postPurchase(userId: Long, productId: Int): PurchaseResponse
 }

--- a/app/src/main/java/org/sopt/sopt_collaboration_panelnow/data/remote/datasourceimpl/GoodsCheckDataSourceImpl.kt
+++ b/app/src/main/java/org/sopt/sopt_collaboration_panelnow/data/remote/datasourceimpl/GoodsCheckDataSourceImpl.kt
@@ -17,6 +17,6 @@ class GoodsCheckDataSourceImpl @Inject constructor(
     override suspend fun getGoodsCheck(productId: Int): BaseResponse<GoodsCheckResponse> =
         goodsCheckService.getGoodsCheck(productId)
 
-    override suspend fun postPurchase(userId: Long, productId: Int): BaseResponse<PurchaseResponse> =
+    override suspend fun postPurchase(userId: Long, productId: Int): PurchaseResponse =
         goodsCheckService.postPurchase(userId, productId)
 }

--- a/app/src/main/java/org/sopt/sopt_collaboration_panelnow/data/remote/service/GoodsCheckService.kt
+++ b/app/src/main/java/org/sopt/sopt_collaboration_panelnow/data/remote/service/GoodsCheckService.kt
@@ -6,6 +6,7 @@ import org.sopt.sopt_collaboration_panelnow.data.remote.dto.response.ProductResp
 import org.sopt.sopt_collaboration_panelnow.data.remote.dto.response.PurchaseResponse
 import retrofit2.http.GET
 import retrofit2.http.Header
+import retrofit2.http.POST
 import retrofit2.http.Path
 import retrofit2.http.Query
 
@@ -20,9 +21,9 @@ interface GoodsCheckService {
         @Path("productId") productId: Int,
     ): BaseResponse<GoodsCheckResponse>
 
-    @GET("products/{productId}/purchase")
+    @POST("products/{productId}/purchase")
     suspend fun postPurchase(
         @Header("userId") userId: Long,
         @Path("productId") productId: Int,
-    ): BaseResponse<PurchaseResponse>
+    ): PurchaseResponse
 }

--- a/app/src/main/java/org/sopt/sopt_collaboration_panelnow/domain/entity/GoodsCheck.kt
+++ b/app/src/main/java/org/sopt/sopt_collaboration_panelnow/domain/entity/GoodsCheck.kt
@@ -4,24 +4,25 @@ data class GoodsCheck(
     val id: Int,
     val imageUrl: String,
     val name: String,
-    val price: Long,
+    val price: Int,
     val phoneNumber: String,
     val exchangeDay: String,
-    val info: String,
-    val usageManual: String,
-    val guide: String,
+    val infoSections: List<InfoSection>
 ) {
     companion object {
         val Empty = GoodsCheck(
-            id = -1,
+            id = 0,
             imageUrl = "",
-            name = "로딩 중...",
-            price = 0L,
+            name = "",
+            price = 0,
             phoneNumber = "",
             exchangeDay = "",
-            info = "",
-            usageManual = "",
-            guide = "",
+            infoSections = emptyList()
         )
     }
 }
+
+data class InfoSection(
+    val label: String,
+    val content: String
+)

--- a/app/src/main/java/org/sopt/sopt_collaboration_panelnow/presentation/main/MainActivity.kt
+++ b/app/src/main/java/org/sopt/sopt_collaboration_panelnow/presentation/main/MainActivity.kt
@@ -4,6 +4,9 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.graphics.Color
+import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import dagger.hilt.android.AndroidEntryPoint
 import org.sopt.sopt_collaboration_panelnow.core.designsystem.theme.PanelNowTheme
 
@@ -14,6 +17,20 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             PanelNowTheme {
+                val systemUiController = rememberSystemUiController()
+                val useDarkIcons = true
+
+                SideEffect {
+                    systemUiController.setStatusBarColor(
+                        color = Color.White,
+                        darkIcons = useDarkIcons
+                    )
+                    systemUiController.setNavigationBarColor(
+                        color = Color.White,
+                        darkIcons = useDarkIcons
+                    )
+                }
+
                 MainScreen()
             }
         }

--- a/app/src/main/java/org/sopt/sopt_collaboration_panelnow/presentation/main/navigation/NaviHost.kt
+++ b/app/src/main/java/org/sopt/sopt_collaboration_panelnow/presentation/main/navigation/NaviHost.kt
@@ -35,7 +35,7 @@ fun NaviHost(
         composable<Detail> { backStakEntry ->
             val productId = backStakEntry.arguments?.getInt("productId") ?: -1
 
-            PointDetailRoute(productId)
+            PointDetailRoute(productId, navController)
         }
 
     }

--- a/app/src/main/java/org/sopt/sopt_collaboration_panelnow/presentation/pointdetail/PointDetailScreen.kt
+++ b/app/src/main/java/org/sopt/sopt_collaboration_panelnow/presentation/pointdetail/PointDetailScreen.kt
@@ -3,19 +3,26 @@ package org.sopt.sopt_collaboration_panelnow.presentation.pointdetail
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavController
+import org.sopt.sopt_collaboration_panelnow.R
+import org.sopt.sopt_collaboration_panelnow.core.common.util.maskPhoneNumber
+import org.sopt.sopt_collaboration_panelnow.core.common.util.toPointFormat
 import org.sopt.sopt_collaboration_panelnow.core.designsystem.theme.PanelNowTheme
 import org.sopt.sopt_collaboration_panelnow.domain.entity.GoodsCheck
+import org.sopt.sopt_collaboration_panelnow.presentation.main.navigation.Exchange
 import org.sopt.sopt_collaboration_panelnow.presentation.pointdetail.component.PointCouponSection
 import org.sopt.sopt_collaboration_panelnow.presentation.pointdetail.component.PointGoodsSection
 import org.sopt.sopt_collaboration_panelnow.presentation.pointdetail.component.PointGuideSection
@@ -27,16 +34,32 @@ import org.sopt.sopt_collaboration_panelnow.presentation.pointdetail.viewmodel.P
 @Composable
 fun PointDetailRoute(
     productId: Int,
+    navController: NavController,
     viewModel: PointDetailViewModel = hiltViewModel(),
 ) {
-    val goodsCheckState by viewModel.goodsCheckState.collectAsState()
+    val goodsCheckState by viewModel.goodsCheckState.collectAsStateWithLifecycle()
+    val purchaseSuccess by viewModel.purchaseSuccess.collectAsStateWithLifecycle()
 
     LaunchedEffect(Unit) {
         viewModel.getGoodsCheck(productId)
     }
 
+    LaunchedEffect(purchaseSuccess) {
+        if (purchaseSuccess) {
+            navController.navigate(Exchange) {
+                popUpTo(Exchange) {
+                    inclusive = true
+                }
+            }
+            viewModel.resetPurchaseSuccess()
+        }
+    }
+
     PointDetailScreen(
-        goodsCheckState = goodsCheckState
+        goodsCheckState = goodsCheckState,
+        onPurchaseClick = {
+            viewModel.postPurchase(productId)
+        }
     )
 }
 
@@ -44,6 +67,7 @@ fun PointDetailRoute(
 fun PointDetailScreen(
     goodsCheckState: GoodsCheck,
     modifier: Modifier = Modifier,
+    onPurchaseClick: () -> Unit = {},
 ) {
     Box(
         modifier = modifier
@@ -62,33 +86,40 @@ fun PointDetailScreen(
                     pointImageUrl = goodsCheckState.imageUrl,
                 )
             }
+
             item {
                 PointCouponSection(
                     couponName = goodsCheckState.name,
-                    couponPoint = goodsCheckState.price.toString(),
-                    phoneNumber = goodsCheckState.phoneNumber,
+                    couponPoint = goodsCheckState.price.toString().toPointFormat(),
+                    phoneNumber = goodsCheckState.phoneNumber.maskPhoneNumber(),
                     exchangeDate = goodsCheckState.exchangeDay,
                     modifier = modifier
                 )
             }
+
             item {
-                PointGoodsSection(
-                    detailText = goodsCheckState.info,
-                )
+                PointGoodsSection()
             }
+
             item {
                 PointGuideSection(
-                    guideText = goodsCheckState.guide,
+                    infoSections = goodsCheckState.infoSections
                 )
+            }
+
+            item {
+                Spacer(modifier = Modifier.height(36.dp))
             }
         }
 
         PointPaySection(
-            label = "Pay with Points",
+            label = "교환하기",
             myPoint = "5000",
             modifier = modifier
                 .align(alignment = Alignment.BottomCenter),
-            canPayed = true
+            canPayed = true,
+            iconRes = R.drawable.ic_point,
+            onPayClick = onPurchaseClick
         )
     }
 }

--- a/app/src/main/java/org/sopt/sopt_collaboration_panelnow/presentation/pointdetail/component/PointGoodsSection.kt
+++ b/app/src/main/java/org/sopt/sopt_collaboration_panelnow/presentation/pointdetail/component/PointGoodsSection.kt
@@ -18,7 +18,6 @@ import org.sopt.sopt_collaboration_panelnow.core.designsystem.theme.PanelNowThem
 
 @Composable
 fun PointGoodsSection(
-    detailText: String,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -37,12 +36,31 @@ fun PointGoodsSection(
             modifier = Modifier
                 .align(Alignment.Start),
         )
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 12.dp, vertical = 20.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(
+                text = stringResource(id = R.string.point_detail_guide_info1),
+                style = PanelNowTheme.typography.bodyR14,
+                color = PanelNowTheme.colors.gray6,
+            )
 
-        Text(
-            text = detailText,
-            style = PanelNowTheme.typography.bodyR14,
-            color = PanelNowTheme.colors.gray6,
-        )
+            Text(
+                text = stringResource(id = R.string.point_detail_guide_info2),
+                style = PanelNowTheme.typography.bodyR14,
+                color = PanelNowTheme.colors.gray6,
+            )
+
+            Text(
+                text = stringResource(id = R.string.point_detail_guide_info3),
+                style = PanelNowTheme.typography.bodyR14,
+                color = PanelNowTheme.colors.gray6,
+            )
+        }
+
     }
 }
 
@@ -50,8 +68,6 @@ fun PointGoodsSection(
 @Composable
 private fun ReviewPointGoodsSection() {
     PanelNowTheme {
-        PointGoodsSection(
-            detailText = "상품 상세 정보",
-        )
+        PointGoodsSection()
     }
 }

--- a/app/src/main/java/org/sopt/sopt_collaboration_panelnow/presentation/pointdetail/component/PointGuideSection.kt
+++ b/app/src/main/java/org/sopt/sopt_collaboration_panelnow/presentation/pointdetail/component/PointGuideSection.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
@@ -15,34 +14,43 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import org.sopt.sopt_collaboration_panelnow.R
 import org.sopt.sopt_collaboration_panelnow.core.designsystem.theme.PanelNowTheme
+import org.sopt.sopt_collaboration_panelnow.domain.entity.InfoSection
 
 @Composable
 fun PointGuideSection(
-    guideText: String,
+    infoSections: List<InfoSection>,
     modifier: Modifier = Modifier,
 ) {
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .background(
-                color = Color.White
-            )
+            .background(color = Color.White)
             .padding(horizontal = 16.dp, vertical = 19.dp),
-        verticalArrangement = Arrangement.spacedBy(10.dp)
+        verticalArrangement = Arrangement.spacedBy(20.dp)
     ) {
         Text(
-            text = stringResource(id = R.string.point_detail_guide),
+            text = stringResource(R.string.point_detail_guide),
             style = PanelNowTheme.typography.titleSb16,
             color = PanelNowTheme.colors.gray6,
-            modifier = Modifier
-                .align(Alignment.Start),
         )
 
-        Text(
-            text = guideText,
-            style = PanelNowTheme.typography.bodyR14,
-            color = PanelNowTheme.colors.gray6,
-        )
+        infoSections.forEach { section ->
+            Column(
+                verticalArrangement = Arrangement.spacedBy(20.dp)
+            ) {
+                Text(
+                    text = "▶ ${section.label}",
+                    style = PanelNowTheme.typography.bodyR14,
+                    color = PanelNowTheme.colors.gray6,
+                )
+
+                Text(
+                    text = section.content,
+                    style = PanelNowTheme.typography.bodyR14,
+                    color = PanelNowTheme.colors.gray6,
+                )
+            }
+        }
     }
 }
 
@@ -51,7 +59,20 @@ fun PointGuideSection(
 private fun PreviewPointGuideSection() {
     PanelNowTheme {
         PointGuideSection(
-            guideText = "포인트 상세 설명 예시 텍스트"
+            infoSections = listOf(
+                InfoSection(
+                    label = "충전권 이용안내",
+                    content = "네이버페이 포인트는 네이버쇼핑/네이버웹툰/네이버예약을 비롯한 45 만개 이상 가맹점에서 현금처럼 이용하실 수 있습니다."
+                ),
+                InfoSection(
+                    label = "사용방법",
+                    content = "모바일 : 네이버페이>우상단 삼선메뉴(=)클릭>결제>쿠폰>쿠폰 등록"
+                ),
+                InfoSection(
+                    label = "이용가이드",
+                    content = "포인트는 1인당 최대 200만원까지 보유하실 수 있습니다."
+                )
+            )
         )
     }
 }

--- a/app/src/main/java/org/sopt/sopt_collaboration_panelnow/presentation/pointdetail/component/PointPaySection.kt
+++ b/app/src/main/java/org/sopt/sopt_collaboration_panelnow/presentation/pointdetail/component/PointPaySection.kt
@@ -21,7 +21,9 @@ import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import org.sopt.sopt_collaboration_panelnow.R
+import org.sopt.sopt_collaboration_panelnow.core.common.extension.dropShadow
 import org.sopt.sopt_collaboration_panelnow.core.common.extension.noRippleClickable
+import org.sopt.sopt_collaboration_panelnow.core.common.util.toPointFormat
 import org.sopt.sopt_collaboration_panelnow.core.designsystem.theme.PanelNowTheme
 
 @Composable
@@ -58,7 +60,7 @@ fun PointPaySection(
             )
 
             Text(
-                text = myPoint,
+                text = myPoint.toPointFormat(),
                 style = PanelNowTheme.typography.titleSb16,
                 color = PanelNowTheme.colors.mainBlue
             )
@@ -100,8 +102,8 @@ private fun PayButton(
         PanelNowTheme.colors.gray2
     }
 
-    Box(
-        modifier = modifier
+    val buttonModifier = if (isEnabled) {
+        modifier
             .background(
                 color = backgroundColor,
                 shape = RoundedCornerShape(
@@ -110,10 +112,36 @@ private fun PayButton(
                     bottomEnd = 32.dp
                 )
             )
-            .noRippleClickable(
-                onClick = onPayClick
+            .dropShadow(
+                shape = RoundedCornerShape(
+                    topStart = 16.dp,
+                    topEnd = 32.dp,
+                    bottomEnd = 32.dp
+                ),
+                color = PanelNowTheme.colors.mainBlue.copy(alpha = 0.5f),
+                blur = 10.dp,
+                offsetY = 0.dp,
+                offsetX = 0.dp,
+                spread = 0.dp
             )
-            .padding(vertical = 16.dp),
+            .noRippleClickable(onClick = onPayClick)
+            .padding(vertical = 16.dp)
+    } else {
+        modifier
+            .background(
+                color = backgroundColor,
+                shape = RoundedCornerShape(
+                    topStart = 16.dp,
+                    topEnd = 32.dp,
+                    bottomEnd = 32.dp
+                )
+            )
+            .noRippleClickable(onClick = onPayClick)
+            .padding(vertical = 16.dp)
+    }
+
+    Box(
+        modifier = buttonModifier,
         contentAlignment = Alignment.Center
     ) {
         Text(
@@ -136,13 +164,13 @@ private fun ReviewPointPaySection() {
         ) {
             PointPaySection(
                 label = "500P 교환하기",
-                myPoint = "4500P",
+                myPoint = "4500",
                 canPayed = false,
                 iconRes = R.drawable.ic_point
             )
             PointPaySection(
                 label = "500P 교환하기",
-                myPoint = "4500P",
+                myPoint = "4500",
                 canPayed = true,
                 iconRes = R.drawable.ic_point
             )

--- a/app/src/main/java/org/sopt/sopt_collaboration_panelnow/presentation/pointdetail/viewmodel/PointDetailViewModel.kt
+++ b/app/src/main/java/org/sopt/sopt_collaboration_panelnow/presentation/pointdetail/viewmodel/PointDetailViewModel.kt
@@ -17,6 +17,11 @@ class PointDetailViewModel @Inject constructor(
     private val _goodsCheckState = MutableStateFlow(GoodsCheck.Empty)
     val goodsCheckState: StateFlow<GoodsCheck> = _goodsCheckState
 
+    private val _purchaseSuccess = MutableStateFlow(false)
+    val purchaseSuccess: StateFlow<Boolean> = _purchaseSuccess
+
+    private val userId: Long = 1L
+
     fun getGoodsCheck(productId: Int) {
         viewModelScope.launch {
             goodsCheckRepository.getGoodsCheck(productId)
@@ -26,5 +31,20 @@ class PointDetailViewModel @Inject constructor(
                 .onFailure {
                 }
         }
+    }
+
+    fun postPurchase(productId: Int) {
+        viewModelScope.launch {
+            goodsCheckRepository.postPurchase(userId, productId)
+                .onSuccess {
+                    _purchaseSuccess.value = true
+                }
+                .onFailure {
+                }
+        }
+    }
+
+    fun resetPurchaseSuccess() {
+        _purchaseSuccess.value = false
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,6 +8,9 @@
     <string name="point_detail_coupon_locate">받으실 곳</string>
     <string name="point_detail_goods_detail">상품 상세</string>
     <string name="point_detail_guide">이용 안내</string>
+    <string name="point_detail_guide_info1">• 포인트 교환 신청 후 변경 또는 취소가 불가능합니다.</string>
+    <string name="point_detail_guide_info2">• 교환 예정일에 등록된 휴대폰 번호로 쿠폰번호가\n   MMS가 발송됩니다.</string>
+    <string name="point_detail_guide_info3">• 쿠폰 유효기간은 교환 일로부터 30일 이내이며 연장\n   불가 상품입니다. 자세한 사항은 교환 후 문자 메세지를\n   통해 확인해 주세요.</string>
 
     <!-- Point Exchange -->
     <string name="point_exchange_my_point">나의 포인트</string>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="Theme.SOPT_COLLABORATION_PANELNOW" parent="android:Theme.Material.Light.NoActionBar" />
+    <style name="Theme.PanelNow" parent="android:Theme.Material.Light.NoActionBar">
+        <item name="android:statusBarColor">@color/white</item>
+        <item name="android:windowLightStatusBar">true</item>
+        <item name="android:navigationBarColor">@color/white</item>
+    </style>
 </resources>


### PR DESCRIPTION
## 📌 PR 요약

작업한 내용
- 포인트 교환 API 연동
- Datasource,Entity,Service 수정 했습니다.
- shadow, format Util 함수 추가
- 포인트 교환 Component(GuideSection,GoodsSection) 수정
- 포인트 교환 (PaySection) 디자인 수정 및 API 연동
- 포인트 교환 Screen 수정
- Color 및 Type 수정

PR 포인트 (to.reviewer)
- Color 는 shadow 사용시 기본 black color 가 필요해서 추가했습니다. 
- tpye 은 letterspacing 은 기존과 동일한데 Paragraph spacing 이 적용 안되어있어서 적용했습니다.
- 포인트 교환 성공 시 추가 컴포넌트 및 이벤트가 없기 때문에 기존 화면으로 돌아가게 연결했습니다.

## 📸 스크린샷
|                스크린샷                |
|:----------------------------------:|
| <video width="360" src="https://github.com/user-attachments/assets/67aaa331-f393-4509-b909-a9e02925a190" /> |
<!-- <img width="360" src="이미지 주소" /> -->



## 📮 관련 이슈
- closed #26 
