### PR TITLE
[feat/#32] 상품 정렬 드롭다운 기능 및 상품 이미지 배경 적용

### DIFF
--- a/app/src/main/java/org/sopt/sopt_collaboration_panelnow/presentation/pointexchange/PointExchangeScreen.kt
+++ b/app/src/main/java/org/sopt/sopt_collaboration_panelnow/presentation/pointexchange/PointExchangeScreen.kt
@@ -116,7 +116,7 @@ fun PointExchangeScreen(
             LazyVerticalGrid(
                 columns = GridCells.Fixed(2),
                 modifier = Modifier
-                    .padding(top = 24.dp, bottom = 16.dp),
+                    .padding(top = 16.dp, bottom = 16.dp),
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalArrangement = Arrangement.spacedBy(24.dp),
                 content = {

--- a/app/src/main/java/org/sopt/sopt_collaboration_panelnow/presentation/pointexchange/PointExchangeScreen.kt
+++ b/app/src/main/java/org/sopt/sopt_collaboration_panelnow/presentation/pointexchange/PointExchangeScreen.kt
@@ -1,6 +1,5 @@
 package org.sopt.sopt_collaboration_panelnow.presentation.pointexchange
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -15,7 +14,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import org.sopt.sopt_collaboration_panelnow.core.designsystem.theme.PanelNowTheme
@@ -25,7 +23,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.runtime.LaunchedEffect
 import androidx.hilt.navigation.compose.hiltViewModel
-import org.sopt.sopt_collaboration_panelnow.R
 import org.sopt.sopt_collaboration_panelnow.core.designsystem.component.PanelNowTopBar
 import org.sopt.sopt_collaboration_panelnow.domain.entity.Product
 import androidx.compose.runtime.getValue
@@ -33,17 +30,19 @@ import androidx.compose.material3.Text
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
 import org.sopt.sopt_collaboration_panelnow.presentation.main.navigation.Detail
+import org.sopt.sopt_collaboration_panelnow.presentation.pointexchange.component.SortDropdown
 
 @Composable
 fun PointExchangeRoute(
     navController: NavHostController,
     viewModel: PointExchangeViewModel = hiltViewModel(),
 ) {
+    val sortOption by viewModel.sortOption.collectAsStateWithLifecycle()
     val products by viewModel.products.collectAsStateWithLifecycle()
     val pointExchangeUiState by viewModel.pointExchangeUiState.collectAsStateWithLifecycle()
 
     LaunchedEffect(Unit) {
-        viewModel.getProducts("default")
+        viewModel.getProducts(sortOption)
     }
 
     LaunchedEffect(Unit) {
@@ -53,11 +52,16 @@ fun PointExchangeRoute(
     PointExchangeScreen(
         currentPoint = pointExchangeUiState.currentPoint,
         usedPoint = pointExchangeUiState.usedPoint,
+        selectedSort = sortOption,
         products = products,
+        onSortSelected = { selected ->
+            viewModel.setSortOption(selected)
+            viewModel.getProducts(selected)
+        },
         onProductClick = { productId ->
             navController.navigate(Detail(pointExchangeUiState.currentPoint, productId))
 
-        }
+        },
     )
 }
 
@@ -65,7 +69,9 @@ fun PointExchangeRoute(
 fun PointExchangeScreen(
     currentPoint: Int,
     usedPoint: Int,
+    selectedSort: String,
     products: List<Product>,
+    onSortSelected: (String) -> Unit,
     onProductClick: (Int) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -99,12 +105,12 @@ fun PointExchangeScreen(
                 .padding(horizontal = 16.dp)
                 .padding(top = 16.dp)
         ) {
-            Image(
-                painter = painterResource(id = R.drawable.ic_dropdown_popularity),
-                contentDescription = "Dropdown",
+            SortDropdown(
+                selectedSort = selectedSort,
+                onSortSelected = onSortSelected,
                 modifier = Modifier
-                    .width(94.dp)
-                    .height(32.dp),
+                    .width(130.dp)
+                    .height(36.dp)
             )
 
             LazyVerticalGrid(
@@ -148,7 +154,9 @@ private fun PointExchangeScreenPreview() {
         PointExchangeScreen(
             currentPoint = 4500,
             usedPoint = 4000,
+            selectedSort = "default",
             products = dummyProducts,
+            onSortSelected = {},
             onProductClick = {},
         )
     }

--- a/app/src/main/java/org/sopt/sopt_collaboration_panelnow/presentation/pointexchange/PointExchangeViewModel.kt
+++ b/app/src/main/java/org/sopt/sopt_collaboration_panelnow/presentation/pointexchange/PointExchangeViewModel.kt
@@ -19,11 +19,18 @@ class PointExchangeViewModel @Inject constructor(
     private val goodsCheckRepository: GoodsCheckRepository,
     private val userRepository: UserRepository,
 ) : ViewModel() {
+    private val _sortOption = MutableStateFlow("default")
+    val sortOption: StateFlow<String> = _sortOption
+
     private val _products = MutableStateFlow<List<Product>>(emptyList())
     val products: StateFlow<List<Product>> = _products
 
     private val _pointExchangeUiState = MutableStateFlow(PointExchangeUiState(currentPoint = 0, usedPoint = 0))
     val pointExchangeUiState: StateFlow<PointExchangeUiState> = _pointExchangeUiState
+
+    fun setSortOption(option: String) {
+        _sortOption.value = option
+    }
 
     fun getProducts(sort: String) {
         viewModelScope.launch {

--- a/app/src/main/java/org/sopt/sopt_collaboration_panelnow/presentation/pointexchange/component/ProductCard.kt
+++ b/app/src/main/java/org/sopt/sopt_collaboration_panelnow/presentation/pointexchange/component/ProductCard.kt
@@ -1,9 +1,14 @@
 package org.sopt.sopt_collaboration_panelnow.presentation.pointexchange.component
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
@@ -24,13 +29,28 @@ fun ProductCard(
             .width(160.dp)
             .noRippleClickable(onClick)
     ) {
-        AsyncImage(
-            model = imageUrl,
-            contentDescription = title,
+        Box(
             modifier = Modifier
                 .width(160.dp)
-                .height(116.dp),
-        )
+                .height(116.dp)
+                .border(
+                    width = 0.5.dp,
+                    color = PanelNowTheme.colors.gray1,
+                    shape = RoundedCornerShape(12.dp),
+                )
+                .background(
+                    color = PanelNowTheme.colors.gray4,
+                    shape = RoundedCornerShape(12.dp),
+                )
+                .clip(RoundedCornerShape(12.dp)),
+            contentAlignment = Alignment.Center,
+        ) {
+            AsyncImage(
+                model = imageUrl,
+                contentDescription = title,
+                modifier = Modifier.fillMaxSize(0.7f)
+            )
+        }
 
         Spacer(modifier = Modifier.height(16.dp))
 
@@ -66,7 +86,7 @@ private fun MyPointCardPreview() {
         ProductCard(
             imageUrl = "",
             title = "네이버페이 포인트쿠폰 3000원권",
-            businessDays = "3",
+            businessDays = "3 영업일 소요",
             points = 3200,
             onClick = {},
         )

--- a/app/src/main/java/org/sopt/sopt_collaboration_panelnow/presentation/pointexchange/component/SortDropdown.kt
+++ b/app/src/main/java/org/sopt/sopt_collaboration_panelnow/presentation/pointexchange/component/SortDropdown.kt
@@ -1,5 +1,6 @@
 package org.sopt.sopt_collaboration_panelnow.presentation.pointexchange.component
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -71,17 +72,12 @@ fun SortDropdown(
         DropdownMenu(
             expanded = expanded,
             onDismissRequest = { expanded = false },
-            modifier = Modifier
-                .border(
-                    width = 1.dp,
-                    color = PanelNowTheme.colors.gray1,
-                    shape = RoundedCornerShape(20.dp)
-                )
-                .clip(RoundedCornerShape(20.dp))
-                .background(
-                    color = PanelNowTheme.colors.white,
-                    shape = RoundedCornerShape(20.dp)
-                ),
+            shape = RoundedCornerShape(20.dp),
+            containerColor = PanelNowTheme.colors.white,
+            border = BorderStroke(
+                width = 1.dp,
+                color = PanelNowTheme.colors.gray1
+            ),
         ) {
             DropdownMenuItem(
                 text = { Text("인기순") },

--- a/app/src/main/java/org/sopt/sopt_collaboration_panelnow/presentation/pointexchange/component/SortDropdown.kt
+++ b/app/src/main/java/org/sopt/sopt_collaboration_panelnow/presentation/pointexchange/component/SortDropdown.kt
@@ -1,0 +1,120 @@
+package org.sopt.sopt_collaboration_panelnow.presentation.pointexchange.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import org.sopt.sopt_collaboration_panelnow.core.designsystem.theme.PanelNowTheme
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import org.sopt.sopt_collaboration_panelnow.R
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.tooling.preview.Preview
+
+@Composable
+fun SortDropdown(
+    selectedSort: String,
+    onSortSelected: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var expanded by remember { mutableStateOf(false) }
+
+    val labelMap = mapOf(
+        "default" to "인기순",
+        "price_asc" to "가격 낮은순",
+        "price_desc" to "가격 높은순",
+    )
+
+    Box(modifier = modifier) {
+        Row(
+            modifier = Modifier
+                .clip(RoundedCornerShape(16.dp))
+                .background(PanelNowTheme.colors.white)
+                .border(
+                    width = 1.dp,
+                    color = PanelNowTheme.colors.gray1,
+                    shape = RoundedCornerShape(20.dp)
+                )
+                .padding(horizontal = 16.dp, vertical = 8.dp)
+                .clickable { expanded = true },
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = labelMap[selectedSort] ?: "인기순",
+                style = PanelNowTheme.typography.titleM14,
+                color = PanelNowTheme.colors.gray6,
+            )
+            Spacer(modifier = Modifier.width(16.dp))
+            Icon(
+                painter = painterResource(id = R.drawable.ic_arrow_dropdown),
+                contentDescription = "arrow",
+                tint = PanelNowTheme.colors.gray6,
+            )
+        }
+
+        DropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+            modifier = Modifier
+                .border(
+                    width = 1.dp,
+                    color = PanelNowTheme.colors.gray1,
+                    shape = RoundedCornerShape(20.dp)
+                )
+                .clip(RoundedCornerShape(20.dp))
+                .background(
+                    color = PanelNowTheme.colors.white,
+                    shape = RoundedCornerShape(20.dp)
+                ),
+        ) {
+            DropdownMenuItem(
+                text = { Text("인기순") },
+                onClick = {
+                    expanded = false
+                    onSortSelected("default")
+                },
+            )
+            DropdownMenuItem(
+                text = { Text("가격 낮은순") },
+                onClick = {
+                    expanded = false
+                    onSortSelected("price_asc")
+                },
+            )
+            DropdownMenuItem(
+                text = { Text("가격 높은순") },
+                onClick = {
+                    expanded = false
+                    onSortSelected("price_desc")
+                },
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun SortDropdownPreview() {
+    PanelNowTheme {
+        SortDropdown(
+            selectedSort = "default",
+            onSortSelected = {}
+        )
+    }
+}

--- a/app/src/main/res/drawable/ic_arrow_dropdown.xml
+++ b/app/src/main/res/drawable/ic_arrow_dropdown.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="11dp"
+    android:height="7dp"
+    android:viewportWidth="11"
+    android:viewportHeight="7">
+  <path
+      android:pathData="M1,1L5.5,5L10,1"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#00152C"
+      android:strokeLineCap="round"/>
+</vector>


### PR DESCRIPTION
## 📌 PR 요약

작업한 내용
- 상품 정렬 드롭다운 기능
- 상품 이미지 배경 적용

PR 포인트 (to.reviewer)
- 상품 카드가 조금 작은 것 같은데 일단은 피그마 크기에 맞췄습니다..

## 📸 스크린샷
|                스크린샷                |
|:----------------------------------:|
| <video width="360" src="https://github.com/user-attachments/assets/345d2f63-69a0-4460-9484-fae7d1b6052e" /> |

## 📮 관련 이슈
- closed #32 
